### PR TITLE
Correctly take requested reviews into account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Updated `octocrab` to 0.8.11.
 
+### Fixed
+- Requested reviews are now correctly taken into account when deciding
+  whether to merge a PR.
+
 ## [1.0.1] - 2021-02-08
 ### Added
 - The `GITHUB_TOKEN` environment variable is now trimmed of whitespace.


### PR DESCRIPTION


### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

After a bunch of testing I unleashed Octobors on one of our repos today,
and oine of the first things it did was to merge a PR that was waiting
for requested reviewers. Oh dear...

It turns out I made a mistake in detection of these requests. Rather
than being in the reviews field with a `Pending` state there is a
requested reviews field that I had missed! This PR takes this field into
account, resolving the problem.

There is a unit test, and I have manually tested this on a PR that would
previously replicate the problem as well.
