### PR TITLE
 Add config option to consider that "comment" reviews request changes

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to Dockerhub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           username: embarkbot
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/config/example.toml
+++ b/config/example.toml
@@ -1,37 +1,40 @@
-# The GitHub user or organisation who owns the repos
+# The GitHub user or organisation who owns the repos.
 owner = "my_github_organisation"
 
 # Optional: If set to true then Octobors will analyze the repos and print what
 # it would do, but not apply any changes.
 dry_run = true
 
-# This [[repos]] block is repeated for each repo you wish to process
+# This [[repos]] block may be repeated for each repo you wish to process.
+
 [[repos]]
-# The name of the repo to process
+
+# The name of the repo to process.
 name = "the_repo_name"
 
-# Optional: The label added when a PR does not have a body. 
+# Optional: The label added when a PR does not have a body.
 # If this is set PRs require a description to be merged.
 needs_description_label = "needs-description"
 
-# The list of statuss that are required to be passed for the PR to be
-# automerged
+# The list of status that are required to be passed for the PR to be
+# automerged.
 required_statuses = ["test", "lint"]
 
-# The label applied when all of the PR's required status checks have passed
+# The label applied when all of the PR's required status checks have passed.
 ci_passed_label = "ci-passed"
 
-# Optional: Label applied when a PR has 1 or more reviewers and all of them are accepted
+# Optional: Label applied when a PR has one or more reviewers and all of them
+# have approved.
 reviewed_label = "reviewed"
 
-# Optional: Label that can be manually added to PRs to block automerge
+# Optional: Label that can be manually added to PRs to block automerge.
 block_merge_label = "dont-merge"
 
 # Optional: The period in seconds between when a PR can be automerged, and when
-# the action actually tries to perform the merge
+# the action actually tries to perform the merge.
 automerge_grace_period = 30
 
-# Optiona: The method to use for merging the PR, defaults to `merge` if we fail
-# to parse or it is unset by the user
-# Can be "Merge", "Rebase" or "Squash"
+# Optional: The method to use for merging the PR, defaults to `merge` if we
+# fail to parse or it is unset by the user. Can be "Merge", "Rebase" or
+# "Squash".
 merge_method = "Rebase"

--- a/config/example.toml
+++ b/config/example.toml
@@ -38,3 +38,10 @@ automerge_grace_period = 30
 # fail to parse or it is unset by the user. Can be "Merge", "Rebase" or
 # "Squash".
 merge_method = "Rebase"
+
+# Optional: With this setting set to true, a "comment" review  counts as if it
+# is requesting changes, even if the user who did it wasn't part of the initial
+# reviewers list. Otherwise, comments have no approval value, and commenting
+# may be considered as an aborted review request (see also
+# https://github.com/EmbarkStudios/octobors/issues/11).
+comment_requests_change = true

--- a/config/test.toml
+++ b/config/test.toml
@@ -5,4 +5,5 @@ dry_run = true
 name = "octotest"
 ci_passed_label = "ci-passed"
 reviewed_label = "reviewed"
+comment_requests_change = true
 required_statuses = []

--- a/config/test.toml
+++ b/config/test.toml
@@ -1,17 +1,8 @@
-owner = "lpil"
+owner = "bnjbvr"
 dry_run = true
 
 [[repos]]
-name = "puter"
+name = "octotest"
 ci_passed_label = "ci-passed"
-required_statuses = []
-
-[[repos]]
-name = "dotfiles"
-ci_passed_label = "ci-passed"
-required_statuses = []
-
-[[repos]]
-name = "archive"
-ci_passed_label = "ci-passed"
+reviewed_label = "reviewed"
 required_statuses = []

--- a/src/context.rs
+++ b/src/context.rs
@@ -137,24 +137,35 @@ impl fmt::Debug for Config {
 pub struct RepoConfig {
     /// The name of the repo
     pub name: String,
+
     /// The label added when a PR does not have a body
     pub needs_description_label: Option<String>,
+
     /// The list of statuss that are required to be passed for the PR to be
     /// automerged
     pub required_statuses: Vec<String>,
+
     /// The label applied when all of the PR's required status checks have passed
     pub ci_passed_label: Option<String>,
+
     /// Label applied when a PR has 1 or more reviewers and all of them are accepted
     pub reviewed_label: Option<String>,
+
     /// Label that can be manually added to PRs to block automerge
     pub block_merge_label: Option<String>,
+
     /// The period in seconds between when a PR can be automerged, and when
     /// the action actually tries to perform the merge
     pub automerge_grace_period: Option<u64>,
+
     /// The method to use for merging the PR, defaults to `merge` if we fail
     /// to parse or it is unset by the user
     #[serde(default)]
     pub merge_method: MergeMethod,
+
+    /// Whether a "comment" review counts as requesting changes. False by default.
+    #[serde(default)]
+    pub comment_requests_change: bool,
 }
 
 #[derive(Debug, Clone, Copy, serde::Deserialize)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -96,14 +96,19 @@ impl Client {
 pub struct Config {
     /// The user or organisation that owns the repos
     pub owner: String,
+
     /// The repos to be run on, and their config
     pub repos: Vec<RepoConfig>,
+
     /// Whether to skip applying the changes or not.
     pub dry_run: bool,
+
     /// The base URL to use GitHub API.  This may be useful if you are using a
     /// proxy for the GitHub API or an enterprise installation.
     pub github_api_base: Option<String>,
+
     /// Extra headers to add to each request made to GitHub's API.
+    #[serde(default)]
     pub extra_headers: Vec<(String, String)>,
 }
 

--- a/src/process/tests.rs
+++ b/src/process/tests.rs
@@ -15,6 +15,7 @@ fn make_context() -> (Pr, context::Client, context::RepoConfig) {
         block_merge_label: Some("block-merge".to_string()),
         automerge_grace_period: Some(10),
         merge_method: context::MergeMethod::Rebase,
+        comment_requests_change: false,
     };
     let pr = Pr {
         id: 13482,

--- a/src/process/tests.rs
+++ b/src/process/tests.rs
@@ -18,6 +18,7 @@ fn make_context() -> (Pr, context::Client, context::RepoConfig) {
     };
     let pr = Pr {
         id: 13482,
+        author: "author".to_owned(),
         number: 1,
         commit_sha: "somesha".to_string(),
         draft: false,


### PR DESCRIPTION
Plus a few cleanups.

This is an attempt to fix #11:  there's an optional additional configuration option that makes it possible to consider a "comment" review as a "request-change" review.

Pros:

- a reviewer who adds a "comment" review doesn't get their review request invalidated. They have to explicitly approve the PR to get up to that point.

Cons:

- a drive-by review "comment" can be blocking a PR from getting merged. In this case, I would think that if someone randomly did a drive-by review of my code, it would be legitimate to ask them for formal review thereafter, and get their approval. So that doesn't seem too unreasonable, and we can try it out and see if it's too often a problem or not.