### PR TITLE
Remove html comments from PR's body before merge.

### DIFF
--- a/src/merge.rs
+++ b/src/merge.rs
@@ -12,7 +12,7 @@ fn remove_html_comments(body: String) -> String {
         if let Some(mut end) = haystack[start..].find("-->") {
             // Let end be relative to haystack[0..].
             end += start;
-            if haystack[(start + "<!--".len())..end].find("<!--").is_some() {
+            if haystack[(start + "<!--".len())..end].contains("<!--") {
                 // Embedded comments, abort!
                 return body;
             }


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Most HTML code comments in PR texts are remains of PR templates that get embedded into the PR's commit message; that may pollute commit logs in the future, if users aren't careful enough and don't remove those manually. This PR proposes a very bespoke hacky method to remove them from the PR's text just before an attempt to merge.

### Related Issues

n/a
