### PR TITLE
Add a trivial review label

### DIFF
--- a/config/example.toml
+++ b/config/example.toml
@@ -27,9 +27,12 @@ ci_passed_label = "ci-passed"
 # have approved.
 reviewed_label = "reviewed"
 
-# Optional: Label that can be manually added to PRs to not block on reviews, for trivial changes.
+# Optional: Label that can be manually added to PRs so as to not block on reviews, for trivial
+# changes.
+# If a reviewer has submitted a request-changes review *before* the bot merged the PR, then an
+# approval review will be required, and the PR won't automatically get merged until then.
 # If there's also a `block_merge_label` set, it has priority over this label being set.
-#trivial_review_label = "trivial"
+#skip_review_label = "trivial"
 
 # Optional: Label that can be manually added to PRs to block automerge.
 block_merge_label = "dont-merge"

--- a/config/example.toml
+++ b/config/example.toml
@@ -27,6 +27,10 @@ ci_passed_label = "ci-passed"
 # have approved.
 reviewed_label = "reviewed"
 
+# Optional: Label that can be manually added to PRs to not block on reviews, for trivial changes.
+# If there's also a `block_merge_label` set, it has priority over this label being set.
+trivial_review_label = "trivial"
+
 # Optional: Label that can be manually added to PRs to block automerge.
 block_merge_label = "dont-merge"
 

--- a/config/example.toml
+++ b/config/example.toml
@@ -29,7 +29,7 @@ reviewed_label = "reviewed"
 
 # Optional: Label that can be manually added to PRs to not block on reviews, for trivial changes.
 # If there's also a `block_merge_label` set, it has priority over this label being set.
-trivial_review_label = "trivial"
+#trivial_review_label = "trivial"
 
 # Optional: Label that can be manually added to PRs to block automerge.
 block_merge_label = "dont-merge"
@@ -48,4 +48,4 @@ merge_method = "Rebase"
 # reviewers list. Otherwise, comments have no approval value, and commenting
 # may be considered as an aborted review request (see also
 # https://github.com/EmbarkStudios/octobors/issues/11).
-comment_requests_change = true
+#comment_requests_change = true

--- a/config/test.toml
+++ b/config/test.toml
@@ -1,9 +1,10 @@
 owner = "bnjbvr"
-dry_run = true
+dry_run = false
 
 [[repos]]
 name = "octotest"
 ci_passed_label = "ci-passed"
 reviewed_label = "reviewed"
+trivial_review_label = "trivial"
 comment_requests_change = true
 required_statuses = []

--- a/config/test.toml
+++ b/config/test.toml
@@ -5,6 +5,6 @@ dry_run = false
 name = "octotest"
 ci_passed_label = "ci-passed"
 reviewed_label = "reviewed"
-trivial_review_label = "trivial"
+skip_review_label = "trivial"
 comment_requests_change = true
 required_statuses = []

--- a/src/context.rs
+++ b/src/context.rs
@@ -151,6 +151,11 @@ pub struct RepoConfig {
     /// Label applied when a PR has 1 or more reviewers and all of them are accepted
     pub reviewed_label: Option<String>,
 
+    /// Label that can be manually added to PRs to not block on reviews, for trivial changes
+    ///
+    /// If there's a `block_merge_label` set, it has priority over this label being set.
+    pub trivial_review_label: Option<String>,
+
     /// Label that can be manually added to PRs to block automerge
     pub block_merge_label: Option<String>,
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -153,8 +153,10 @@ pub struct RepoConfig {
 
     /// Label that can be manually added to PRs to not block on reviews, for trivial changes
     ///
+    /// If a reviewer has submitted a request-changes review *before* the bot merged the PR, then
+    /// an approval review will be required, and the PR won't automatically get merged until then.
     /// If there's a `block_merge_label` set, it has priority over this label being set.
-    pub trivial_review_label: Option<String>,
+    pub skip_review_label: Option<String>,
 
     /// Label that can be manually added to PRs to block automerge
     pub block_merge_label: Option<String>,

--- a/src/process.rs
+++ b/src/process.rs
@@ -187,7 +187,7 @@ impl<'a> Analyzer<'a> {
 
     fn requires_reviews(&self) -> bool {
         // Either there's a trivial label, and the PR contains it, so reviews are optional.
-        if let Some(ref trivial_label) = self.config.trivial_review_label {
+        if let Some(ref trivial_label) = self.config.skip_review_label {
             if self.pr.labels.contains(trivial_label) {
                 log::info!("Not blocking on reviews because of trivial review label");
                 return false;

--- a/src/process/tests.rs
+++ b/src/process/tests.rs
@@ -112,7 +112,7 @@ async fn trivial_merge_not_blocked_on_pending_reviews() {
 }
 
 #[tokio::test]
-async fn trivial_merge_blocked_on_requested_changes () {
+async fn trivial_merge_blocked_on_requested_changes() {
     let (mut pr, client, mut config) = make_context();
 
     // It's trivial
@@ -138,7 +138,7 @@ async fn trivial_merge_blocked_on_requested_changes () {
 }
 
 #[tokio::test]
-async fn trivial_merge_with_approval () {
+async fn trivial_merge_with_approval() {
     let (mut pr, client, mut config) = make_context();
 
     // It's trivial
@@ -162,8 +162,6 @@ async fn trivial_merge_with_approval () {
             .set_label("needs-description", Presence::Absent)
     );
 }
-
-
 
 #[tokio::test]
 async fn draft_pr_actions() {

--- a/src/process/tests.rs
+++ b/src/process/tests.rs
@@ -15,7 +15,7 @@ fn make_context() -> (Pr, context::Client, context::RepoConfig) {
         reviewed_label: Some("reviewed".to_string()),
         block_merge_label: Some("block-merge".to_string()),
         automerge_grace_period: Some(10),
-        trivial_review_label: None,
+        skip_review_label: None,
         merge_method: context::MergeMethod::Rebase,
         comment_requests_change: false,
     };
@@ -93,7 +93,7 @@ async fn trivial_merge_not_blocked_on_pending_reviews() {
     let (mut pr, client, mut config) = make_context();
 
     // It's trivial
-    config.trivial_review_label = Some("trivial :)".to_string());
+    config.skip_review_label = Some("trivial :)".to_string());
     pr.labels.insert("trivial :)".to_string());
 
     // But a few reviews are pending
@@ -116,7 +116,7 @@ async fn trivial_merge_blocked_on_requested_changes() {
     let (mut pr, client, mut config) = make_context();
 
     // It's trivial
-    config.trivial_review_label = Some("trivial :)".to_string());
+    config.skip_review_label = Some("trivial :)".to_string());
     pr.labels.insert("trivial :)".to_string());
 
     // But a few reviews are pending
@@ -142,7 +142,7 @@ async fn trivial_merge_with_approval() {
     let (mut pr, client, mut config) = make_context();
 
     // It's trivial
-    config.trivial_review_label = Some("trivial :)".to_string());
+    config.skip_review_label = Some("trivial :)".to_string());
     pr.labels.insert("trivial :)".to_string());
 
     // But a few reviews are pending


### PR DESCRIPTION
This adds a new trivial review label to the configuration, which if it is present, makes it so that the PR doesn't block on reviews. Other preconditions may still prevail (e.g. CI must pass), but the requirement on reviewers in particular is relaxed.

Fixes #34.