### PR TITLE
Don't add "reviewed" label to "trivial" PRs

### DIFF
--- a/src/review.rs
+++ b/src/review.rs
@@ -35,8 +35,10 @@ pub struct Reviews {
     author: String,
 }
 
+#[derive(Debug)]
 pub enum Approval {
     Required,
+    #[allow(dead_code)]
     Optional,
 }
 
@@ -59,7 +61,7 @@ impl Reviews {
     pub fn approved(&self, approval_required: Approval) -> bool {
         let mut approved = matches!(approval_required, Approval::Optional);
         for (user, review) in self.review_by_nick.iter() {
-            tracing::info!(user = %user, review = ?review, "review");
+            tracing::info!(%user, ?review, "review");
             match review {
                 Status::Approved => approved = true,
                 Status::ChangeRequested => return false,


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Fixes https://github.com/EmbarkStudios/octobors/issues/37

The biggest change is that `pr_approved` now always checks whether the PR is actually approved or not. It doesn't consider trivial PRs to always be approved. This gives us more control over when to add the "reviewed" label since that previously was always added if a PR was approved.