### PR TITLE
Add maintenance label

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "cron"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ff76b51e4c068c52bfd2866e1567bee7c567ae8f24ada09fd4307019e25eab7"
+dependencies = [
+ "chrono",
+ "nom",
+ "once_cell",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +490,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +514,16 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -543,6 +570,7 @@ version = "1.4.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "cron",
  "futures",
  "http",
  "octocrab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ toml = "0.5"
 tokio = { version = "1.14", features = ["macros", "rt-multi-thread"] }
 # Date and time data structures
 chrono = "0.4"
+cron = "0.12"
+
 # Futures combinators
 futures = "0.3.12"
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -158,8 +158,24 @@ pub struct RepoConfig {
     /// If there's a `block_merge_label` set, it has priority over this label being set.
     pub skip_review_label: Option<String>,
 
-    /// Label that can be manually added to PRs to block automerge
+    /// Labels that can be manually added to PRs to block automerge
     pub block_merge_label: Option<String>,
+
+    /// Label that can be added to PR's to prevent auto merging until the maintenance time is med.
+    pub maintenance_label: Option<String>,
+
+    /// The maintenance time at which PR's will be merged when `maintenance_label` is set and PR can be merged.
+    /// If not set, there is no maintenance time, and it is expected to manually remove the maintenance label.
+    ///
+    /// Expected Format:
+    ///
+    /// ```
+    /// // sec  min   hour   day of month   month   day of week   year
+    ///     0   30   9,12,15     1,15       May-Aug  Mon,Wed,Fri  2018/2
+    /// ```
+    ///
+    /// This input is parsed by the [cron](https://github.com/zslayton/cron) crate.
+    pub maintenance_time: Option<String>,
 
     /// The period in seconds between when a PR can be automerged, and when
     /// the action actually tries to perform the merge


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Fixes: #39 

This adds a maintenance label that if added to PR it will block merging even if all other conditions are med. In addition, octoborus can be configured with a maintenance cron job time that if set will merge all PRs with the maintenance label at the scheduled time.