### PR TITLE
Maintain most spacing and paragraph structure in commit messages

### DIFF
--- a/src/merge.rs
+++ b/src/merge.rs
@@ -33,7 +33,7 @@ fn remove_html_comments(body: String) -> String {
     let lines = result
         .trim()
         .split('\n')
-        .map(|line| line.trim().split_whitespace().collect::<Vec<_>>().join(" "))
+        .map(|line| line.split_whitespace().collect::<Vec<_>>().join(" "))
         .collect::<Vec<_>>();
 
     // - overall, make sure that paragraph are split across at most two blank lines.


### PR DESCRIPTION
Does what it says on the tin. I've added tests that didn't pass before this change, and had to tweak a few tests, so one can easily look at the changes. This shouldn't badly interact with Markdown in general, unless we have very whitespace-specific content in code blocks that seems fine to have.

Fixes #33.