### PR TITLE
Add label to PR on internal errors

### DIFF
--- a/config/test.toml
+++ b/config/test.toml
@@ -1,4 +1,4 @@
-owner = "bnjbvr"
+owner = "davidpdrsn"
 dry_run = false
 
 [[repos]]
@@ -8,6 +8,7 @@ reviewed_label = "reviewed"
 skip_review_label = "trivial"
 needs_description_label = "needs-description"
 block_merge_label = "block-merge"
+error_label = "octobors-error"
 comment_requests_change = true
 react_to_comments = true
 required_statuses = []

--- a/src/context.rs
+++ b/src/context.rs
@@ -207,6 +207,9 @@ pub struct RepoConfig {
     /// Label that can be manually added to PRs to block automerge
     pub block_merge_label: Option<String>,
 
+    /// Label that will be added to PRs where octobors encountered internal errors
+    pub error_label: Option<String>,
+
     /// The period in seconds between when a PR can be automerged, and when
     /// the action actually tries to perform the merge
     pub automerge_grace_period: Option<u64>,

--- a/src/process/tests.rs
+++ b/src/process/tests.rs
@@ -14,6 +14,7 @@ fn make_context() -> (Pr, context::Client, context::RepoConfig) {
         ci_passed_label: Some("ci-passed".to_string()),
         reviewed_label: Some("reviewed".to_string()),
         block_merge_label: Some("block-merge".to_string()),
+        error_label: Some("octobors-error".to_string()),
         automerge_grace_period: Some(10),
         skip_review_label: None,
         merge_method: context::MergeMethod::Rebase,


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

We've seen some deserialization errors in the logs causing PRs not to get
merged. From the outside you can't see that and the bot is just silent.

This makes the bot add an `error_label` to failed PRs.
