### PR TITLE
Print error output on one line

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ use tracing as log;
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() {
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::builder()
@@ -86,6 +86,15 @@ async fn main() -> Result<()> {
         .without_time()
         .init();
 
+    match try_main().await {
+        Ok(()) => {}
+        Err(err) => {
+            log::error!("Something went wrong: {err:#}");
+        }
+    }
+}
+
+async fn try_main() -> Result<()> {
     let app = octobors::Octobors::new(&get_config_path()?)?;
     log::info!("configuration: {:?}", app.config);
     app.process_all().await

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@
 )]
 // END - Embark standard lints v0.4
 
-use std::path::PathBuf;
+use std::{path::PathBuf, process::ExitCode};
 
 use anyhow::{Context as _, Result};
 use log::metadata::LevelFilter;
@@ -76,7 +76,7 @@ use tracing as log;
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> ExitCode {
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::builder()
@@ -87,9 +87,10 @@ async fn main() {
         .init();
 
     match try_main().await {
-        Ok(()) => {}
+        Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
             log::error!("Something went wrong: {err:#}");
+            ExitCode::FAILURE
         }
     }
 }


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

If an error bubles all the way up to `main` we would previously print it across
several lines. That makes things harder to search for in the logs.

This changes it so the error (including the source chain) is printed on one
line.
