### PR TITLE
Tweak tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi",
 ]
@@ -671,6 +671,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "tracing-logfmt",
  "tracing-subscriber",
 ]
 
@@ -1049,6 +1050,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+dependencies = [
+ "itoa",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+dependencies = [
+ "time-core",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,6 +1202,18 @@ dependencies = [
  "lazy_static",
  "log",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-logfmt"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5517717fb9744e201860d29fafc7786514e50316a87c30f3e15489f40e63ca00"
+dependencies = [
+ "time 0.3.20",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0"
 # logging and tracing macros
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-logfmt = "0.3.1"
 # Used for making all of the requests to github
 octocrab = { version = "0.13", default-features = false, features = ["rustls"] }
 http = "*"

--- a/config/test.toml
+++ b/config/test.toml
@@ -1,4 +1,4 @@
-owner = "bnjbvr"
+owner = "davidpdrsn"
 dry_run = false
 
 [[repos]]

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,9 +71,8 @@
 use std::{path::PathBuf, process::ExitCode};
 
 use anyhow::{Context as _, Result};
-use log::metadata::LevelFilter;
-use tracing as log;
-use tracing_subscriber::EnvFilter;
+use tracing::metadata::LevelFilter;
+use tracing_subscriber::{prelude::*, EnvFilter};
 
 #[tokio::main]
 async fn main() -> ExitCode {
@@ -89,7 +88,7 @@ async fn main() -> ExitCode {
     match try_main().await {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
-            log::error!("Something went wrong: {err:#}");
+            tracing::error!("Something went wrong: {err:#}");
             ExitCode::FAILURE
         }
     }
@@ -97,7 +96,7 @@ async fn main() -> ExitCode {
 
 async fn try_main() -> Result<()> {
     let app = octobors::Octobors::new(&get_config_path()?)?;
-    log::info!("configuration: {:?}", app.config);
+    tracing::info!("configuration: {:?}", app.config);
     app.process_all().await
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,18 +71,13 @@
 use std::{path::PathBuf, process::ExitCode};
 
 use anyhow::{Context as _, Result};
-use tracing::metadata::LevelFilter;
 use tracing_subscriber::{prelude::*, EnvFilter};
 
 #[tokio::main]
 async fn main() -> ExitCode {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::builder()
-                .with_default_directive(LevelFilter::INFO.into())
-                .from_env_lossy(),
-        )
-        .without_time()
+    tracing_subscriber::registry()
+        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| "octobors=debug".into()))
+        .with(tracing_logfmt::layer())
         .init();
 
     match try_main().await {

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1,5 +1,3 @@
-use tracing as log;
-
 /// Removes HTML comments (in the form of <!-- comments -->) from the given string.
 /// If running into nested comments, aborts and returns the initial string.
 fn remove_html_comments(body: String) -> String {
@@ -82,7 +80,7 @@ pub async fn queue(
                 // Github started calculating the merge state of the PR if it hadn't
                 // already done so before our request, so if it didn't finish, we need
                 // to poll it again
-                log::warn!("Merge state is unknown, retrying");
+                tracing::warn!("Merge state is unknown, retrying");
 
                 retry_count += 1;
                 tokio::time::sleep(std::time::Duration::from_secs(10)).await;
@@ -121,7 +119,10 @@ pub async fn queue(
                             Ok(res) => {
                                 // Even though the response contains a 'merged' boolean, the API docs
                                 // seem to indicate that this would never be false, so we just assume it merged
-                                log::info!("Successfully merged: {}", res.sha.unwrap_or_default());
+                                tracing::info!(
+                                    "Successfully merged: {}",
+                                    res.sha.unwrap_or_default()
+                                );
 
                                 None
                             }
@@ -130,13 +131,13 @@ pub async fn queue(
                     }
                     MergeableState::Unknown => unreachable!(),
                     _ => {
-                        log::warn!("Ignoring unknown merge state {:?}", ms);
+                        tracing::warn!("Ignoring unknown merge state {:?}", ms);
                         return Ok(());
                     }
                 };
 
                 if let Some(abort_reason) = abort_reason {
-                    log::warn!("not able to automerge: {}", abort_reason);
+                    tracing::warn!("not able to automerge: {}", abort_reason);
                 }
             }
         }


### PR DESCRIPTION
- Don't import `tracing` as `log`, just use `tracing`
- use tracing_logfmt

### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Changes the tracing output to use `logfmt` which is easier to query in grafana.
