### PR TITLE
Block merge if graphite downstack is not yet merged

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -76,7 +76,7 @@ impl Client {
             comments.extend(previous.items);
             page = self.inner.get_page(&previous.next).await?;
         }
-        tracing::info!(?comments, "comments we got from github api");
+        //tracing::info!(?comments, "comments we got from github api");
         Ok(comments)
     }
 
@@ -132,6 +132,7 @@ impl Client {
             .await
             .context("Getting the bot user id")?
             .login;
+        tracing::error!("{}", nick);
         *self.bot_nick.borrow_mut() = Some(nick.clone());
         Ok(nick)
     }
@@ -206,6 +207,9 @@ pub struct RepoConfig {
 
     /// Label that can be manually added to PRs to block automerge
     pub block_merge_label: Option<String>,
+
+    /// Label that can be manually added to PRs to block automerge
+    pub graphite_label: Option<String>,
 
     /// The period in seconds between when a PR can be automerged, and when
     /// the action actually tries to perform the merge

--- a/src/context.rs
+++ b/src/context.rs
@@ -76,7 +76,7 @@ impl Client {
             comments.extend(previous.items);
             page = self.inner.get_page(&previous.next).await?;
         }
-        //tracing::info!(?comments, "comments we got from github api");
+        tracing::info!(?comments, "comments we got from github api");
         Ok(comments)
     }
 
@@ -132,7 +132,7 @@ impl Client {
             .await
             .context("Getting the bot user id")?
             .login;
-        tracing::error!("{}", nick);
+
         *self.bot_nick.borrow_mut() = Some(nick.clone());
         Ok(nick)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,7 @@ impl<'a> RepoProcessor<'a> {
         let pr = Pr::from_octocrab_pull_request(pr);
 
         let actions = Analyzer::new(&pr, self.client, self.repo_config)
+            .await?
             .required_actions()
             .await?;
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -414,11 +414,7 @@ impl<'a> Analyzer<'a> {
 
     fn merge_blocked_by_graphite(&self) -> bool {
         let mut is_graphite_comment = false;
-        for comment in self
-            .pr_comments
-            .iter()
-            .filter_map(|x| x.body.clone())
-        {
+        for comment in self.pr_comments.iter().filter_map(|x| x.body.clone()) {
             is_graphite_comment |= comment.contains("Current dependencies on/for this PR:");
         }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -413,16 +413,16 @@ impl<'a> Analyzer<'a> {
     }
 
     fn merge_blocked_by_graphite(&self) -> bool {
+        let mut is_graphite_comment = false;
         for comment in self
             .pr_comments
             .iter()
             .filter_map(|x| x.body.clone())
-            .collect::<Vec<_>>()
         {
-            return comment.contains("Current dependencies on/for this PR:");
+            is_graphite_comment |= comment.contains("Current dependencies on/for this PR:");
         }
 
-        false
+        is_graphite_comment
     }
 
     fn requires_reviews(&self) -> bool {


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

For graphite we want to have a protection mechanism that prevents stack branches from merging if downstack branches are not yet approved and merged. 

I don't really know how to test this 'properly' or if it does what I want it to do. What would be a good way to test this before publishing life?

## Some solutions

The tricky part is to check if downstack PR's are merged and only block merging in that case. Its tricky because we don't have access to the downstack PR's from within the code, as the code is based around analyzing the current PR. 

### Inspecting HTML 

One possible approach is to inspect the graphites HTML comment code, assuming it remains relatively stable over time. By checking if the PR icon contains the 'open' class, we can determine whether the PR has been merged or not. This can be achieved by examining the following condition:


```rust
    async fn merge_blocked_by_graphite(&self) -> anyhow::Result<bool> {
        let pr_comments = self
            .client
            .get_pull_request_comments(self.config.name.as_str(), self.pr.number)
            .await?;

        for comment in pr_comments.iter().filter_map(|x| x.body_html) {
            if comment.contains("Current dependencies on/for this PR:") {
                let stack_pr_opened_status = comment
                    .lines()
                    .into_iter()
                    .filter(|x| x.contains("PR"))
                    .map(|x| x.contains("octicon-git-pull-request open color-fg-open"))
                    .collect::<Vec<_>>();

                let mut downstack_pr_opened = false;
                for current_opened in stack_pr_opened_status {
                    if downstack_pr_opened {
                        return Ok(true); // A downstack pr is opened, block till downstack branch is closed.
                    }
                    downstack_pr_opened = current_opened
                }                
            }
        }

        Ok(false)
    }
```

### Two labels

An other approach is to add the block label only once to the Pull Request (PR). If the user removes the label, we should refrain from re-adding it to the PR. However, achieving this may not be straightforward. One potential solution is to introduce a second label that doesn't block the PR but serves as an indication that it is a "graphite" PR. We can add the block label only if the "graphite" label is not yet set. Consequently, if the user removes the block label and the "graphite" label is present, we won't add the block label again.

### Iterating PR's

In the lib.rs file, we retrieve all the PRs from the repository. An alternative approach is to pass these PRs to the 'Analyzer', which is responsible for analyzing individual PRs. Within the 'Analyzer', we can extract the PR descriptions from the body of the Graphite's PR. By doing so, we can obtain a list of related PRs. From this list, we can then proceed to check the statuses of the stack PRs.
