### PR TITLE
Fix publish container images action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.64.0-slim-buster as build
+FROM rust:1.77.2-slim-buster as build
 
 RUN set -eux; \
     # Install musl-tools so that we can compile with musl libc


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

The publish container images action for 1.7.0 broke as seen here: https://github.com/EmbarkStudios/octobors/actions/runs/8833054040/job/24251649282
Fixes this by upgrading rust version to 1.77.2 in the Dockerfile.

Tested manually by build the image.